### PR TITLE
DOC-5692 archived/deprecated github repos

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -21,3 +21,4 @@ asciidoc:
     astra-streaming-examples-repo: 'https://github.com/datastax/astra-streaming-examples'
     zookeeper-reg: 'Apache ZooKeeper(TM)'
     zookeeper-short: 'ZooKeeper'
+    kaap: 'Kubernetes Autoscaling for Apache Pulsar (KAAP)'

--- a/modules/ROOT/pages/faqs.adoc
+++ b/modules/ROOT/pages/faqs.adoc
@@ -35,7 +35,7 @@ Yes, {product} is open source using the Apache 2.0 license. You can find the sou
 Yes.
 You can run the {product} on {luna-streaming} or {pulsar-short} running on any Kubernetes platform, including Minikube, K8d, Kind, Google Kubernetes Engine (GKE), Microsoft Azure Kubernetes Service, Amazon Kubernetes Service (AKS), and other commonly used platforms.
 
-You can deploy {product} as proxy extension using the https://github.com/datastax/pulsar-helm-chart[{company} Helm chart for {luna-streaming} and {pulsar}].
+You can deploy {product} as proxy extension using xref:kaap-operator:ROOT:index.adoc[{kaap}].
 
 === How do I install {product}?
 

--- a/modules/ROOT/pages/faqs.adoc
+++ b/modules/ROOT/pages/faqs.adoc
@@ -34,8 +34,7 @@ Yes, {product} is open source using the Apache 2.0 license. You can find the sou
 
 Yes.
 You can run the {product} on {luna-streaming} or {pulsar-short} running on any Kubernetes platform, including Minikube, K8d, Kind, Google Kubernetes Engine (GKE), Microsoft Azure Kubernetes Service, Amazon Kubernetes Service (AKS), and other commonly used platforms.
-
-You can deploy {product} as proxy extension using xref:kaap-operator:ROOT:index.adoc[{kaap}].
+For more information, see xref:installation:getting-started.adoc[].
 
 === How do I install {product}?
 

--- a/modules/installation/attachments/values.yaml
+++ b/modules/installation/attachments/values.yaml
@@ -1,0 +1,74 @@
+extra:
+  broker: false
+  brokerSts: true
+  proxy: true
+  wsproxy: false
+  bastion: false
+
+zookeeper:
+  replicaCount: 1
+
+bookkeeper:
+  replicaCount: 1
+
+broker:
+  component: "broker" # this has to match brokerSts naming
+  replicaCount: 0
+
+brokerSts:
+  component: "broker" # this has to match broker naming
+  replicaCount: 1
+  functionsWorkerEnabled: true # to overcome the need for functions working
+  ledger: # the default assumes 2 bookies but this chart only deploys 1
+    defaultEnsembleSize: 1
+    defaultAckQuorum: 1
+    defaultWriteQuorum: 1
+  service:
+    ports:
+      - name: http
+        port: 8080
+      - name: pulsar
+        port: 6650
+
+proxy:
+  component: "proxy"
+  replicaCount: 1
+  service:
+    ports:
+      - name: "http"
+        port: 8080
+        protocol: TCP
+      - name: "pulsar"
+        port: 6650
+        protocol: TCP
+  configData:
+    PULSAR_PREFIX_amqpListeners: "amqp://0.0.0.0:5672"
+  extensions:
+    enabled: true
+    extensions: "rabbitmq"
+    containerPorts:
+      - name: amqp
+        containerPort: 5672
+    servicePorts:
+      - name: amqp
+        port: 5672
+        protocol: TCP
+        targetPort: amqp
+
+image:
+  proxy:
+    repository: datastax/lunastreaming-all # so we get the starlight for rabbitmq extension
+    pullPolicy: IfNotPresent
+    tag: 2.10_2.4
+  brokerSts:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.10_2.4
+  zookeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.10_2.4
+  bookkeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.10_2.4

--- a/modules/installation/pages/getting-started.adoc
+++ b/modules/installation/pages/getting-started.adoc
@@ -76,10 +76,10 @@ The Luna Helm chart simplifies deployment of {product} as a protocol handler.
 The following steps explain how to deploy a {luna-streaming} Helm chart to create a simple {pulsar-short} cluster with the {product} extension ready for use.
 +
 [IMPORTANT]
-====
+=====
 The {company} Luna Helm chart used in this example is deprecated.
-For Kubernetes deployments, use xref:kaap-operator:ROOT:index.adoc[{kaap}].
-====
+For Kubernetes deployments, {company} recommends xref:kaap-operator:ROOT:index.adoc[{kaap}].
+=====
 +
 . Make sure you meet the following prerequisites:
 +
@@ -87,8 +87,15 @@ For Kubernetes deployments, use xref:kaap-operator:ROOT:index.adoc[{kaap}].
 * Install https://kubernetes.io/docs/tasks/tools/[kubectl CLI] version 1.23.4 or later.
 * Have access to a Kubernetes cluster with permission to create a namespace, deployments, and pods.
 +
-. Install the xref:installation:attachment$values.yaml[{company} Luna Helm chart] using a minimal values file.
-The following command creates a Helm release named `my-pulsar-cluster` using the Helm chart within a Kubernetes namespace named `datastax-pulsar`.
+. Add the {company} Helm chart repo to your Helm store:
++
+[source,shell]
+----
+helm repo add datastax-pulsar https://datastax.github.io/pulsar-helm-chart
+----
++
+. Install the Helm chart using a xref:installation:attachment$values.yaml[minimal values file].
+The following command creates a Helm release named `my-pulsar-cluster` using the {company} Luna Helm chart within a Kubernetes namespace named `datastax-pulsar`.
 This minimal configuration creates only the essential components and has no ingress or load balanced services.
 +
 [source,shell]

--- a/modules/installation/pages/getting-started.adoc
+++ b/modules/installation/pages/getting-started.adoc
@@ -73,7 +73,13 @@ Protocol handler (Helm chart)::
 The {product} extension is included in the `luna-streaming-all` image used to deploy a Luna cluster.
 The Luna Helm chart simplifies deployment of {product} as a protocol handler.
 +
-The following steps explain how to deploy a {luna-streaming} Helm chart to create a simple {pulsar-short} cluster with the {product} extension ready for use:
+The following steps explain how to deploy a {luna-streaming} Helm chart to create a simple {pulsar-short} cluster with the {product} extension ready for use.
++
+[IMPORTANT]
+====
+The {company} Luna Helm chart used in this example is deprecated.
+For Kubernetes deployments, use xref:kaap-operator:ROOT:index.adoc[{kaap}].
+====
 +
 . Make sure you meet the following prerequisites:
 +
@@ -81,24 +87,16 @@ The following steps explain how to deploy a {luna-streaming} Helm chart to creat
 * Install https://kubernetes.io/docs/tasks/tools/[kubectl CLI] version 1.23.4 or later.
 * Have access to a Kubernetes cluster with permission to create a namespace, deployments, and pods.
 +
-. Add the {company} Helm chart repo to your Helm store:
-+
-[source,shell]
-----
-helm repo add datastax-pulsar https://datastax.github.io/pulsar-helm-chart
-----
-+
-. Install the Helm chart using a minimal values file.
-The following command creates a Helm release named `my-pulsar-cluster` using the {company} Luna Helm chart within a Kubernetes namespace named `datastax-pulsar`.
+. Install the xref:installation:attachment$values.yaml[{company} Luna Helm chart] using a minimal values file.
+The following command creates a Helm release named `my-pulsar-cluster` using the Helm chart within a Kubernetes namespace named `datastax-pulsar`.
 This minimal configuration creates only the essential components and has no ingress or load balanced services.
 +
 [source,shell]
 ----
-VALUES_URL="https://raw.githubusercontent.com/datastaxdevs/luna-streaming-examples/main/starlight-for-rabbitmq/values.yaml"
 helm install \
   --namespace datastax-pulsar \
   --create-namespace \
-  --values $VALUES_URL \
+  --values path/to/values.yaml \
   --version 3.0.4 \
   my-pulsar-cluster \
   datastax-pulsar/pulsar


### PR DESCRIPTION
* Luna streaming examples repo is archived.
* Pulsar helm chart repo is deprecated with KAAP as the replacement. This effectively invalidates the Luna Helm Chart/values.yml steps but I wasn't sure if I should completely remove them.